### PR TITLE
fix: do not start a new release before the current one is done

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -17,7 +17,7 @@ on:  # yamllint disable-line rule:truthy
 # If multiple pull requests are merged before a release is done, keep building the current one and then build the next
 # ones together
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -14,6 +14,12 @@ on:  # yamllint disable-line rule:truthy
       - Pipfile
       - Pipfile.lock
 
+# If multiple pull requests are merged before a release is done, keep building the current one and then build the next
+# ones together
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 jobs:
   release:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
If the current version is `v1` and we merge two PRs at roughly the same time, then both will write a Docker image tagged `v2` 😱

This PR prevents that from happening.
