### PR TITLE
fix: parse output files from tj-actions/changed-files

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -1,7 +1,7 @@
 ---
 name: Release new version
 
-on:  # yamllint disable-line rule:truthy
+on:
   pull_request:
     types:
       - closed
@@ -13,12 +13,6 @@ on:  # yamllint disable-line rule:truthy
       - Dockerfile
       - Pipfile
       - Pipfile.lock
-
-# If multiple pull requests are merged before a release is done, keep building the current one and then build the next
-# ones together
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
 
 jobs:
   release:

--- a/src/mpyl/utilities/repo/__init__.py
+++ b/src/mpyl/utilities/repo/__init__.py
@@ -4,7 +4,6 @@ Represents the files modified in this unit of change (pull request, etc).
 
 import json
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional


### PR DESCRIPTION
We found a problem with releasing concurrent PRs, so we need another release that actually includes the changes in https://github.com/Vandebron/gh-mpyl/pull/90.

The problem was addressed by requiring merge queues.