### PR TITLE
ci: fix yamlfix and yq fighting each other

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     hooks:
       - id: check-ast  # simply checks whether the files parse as valid python
       - id: check-json  # checks json files for parseable syntax
-        exclude: devcontainer.json  # devcontainers.json is JSONC (JSON with comments) 
+        exclude: devcontainer.json  # devcontainers.json is JSONC (JSON with comments)
       - id: check-xml  # checks xml files for parseable syntax
       - id: check-added-large-files  # prevents giant files from being committed
       - id: check-executables-have-shebangs  # ensures that (non-binary) executables have a shebang

--- a/yamlfix.toml
+++ b/yamlfix.toml
@@ -3,3 +3,4 @@
 sequence_style = "keep_style"
 whitelines = 1
 line_length = 999
+comments_min_spaces_from_content = 1


### PR DESCRIPTION
When we release a new version of `gh-mpyl`, we [use yq to replace the docker image tag](https://github.com/Vandebron/gh-mpyl/blob/main/.github/workflows/ci-release.yaml#L92) with the newly built one. Unfortunately, `yq` rewrites all comments using a single space:

<img width="2257" alt="image" src="https://github.com/user-attachments/assets/8ac82007-6102-472b-ac01-7843d64a51a2">

AFAIK this is non-configurable.

The next time we make a change to this file (e.g. in a PR), our `yamlfix` configuration will [automatically change this to two spaces](https://lyz-code.github.io/yamlfix/#comments-min-spaces-from-content):

<img width="2246" alt="image" src="https://github.com/user-attachments/assets/422a7f4c-c593-4fcd-a2d9-44b3b37bfccb">

And this dance will keep on forever.

This PR stops the music.   

