### PR TITLE
fix: run container as root again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,14 +23,12 @@ WORKDIR /app/mpyl
 # to run this image as root until they decide to fix this glaring issue.
 # See https://github.com/actions/runner/issues/863 for more details.
 # USER vdbnonroot
-ENV WORKON_HOME=/github/home
-ENV PIPENV_CUSTOM_VENV_NAME=gh-mpyl
 
 # Install the project dependencies.
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 COPY Pipfile Pipfile.lock ./
-RUN pipenv sync
+RUN pipenv sync --system
 
 # Copy the source code into the container.
 COPY --link --parents src/mpyl ./
@@ -49,5 +47,5 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /repo
 
 # Run the application.
-ENTRYPOINT ["pipenv", "run", "python", "/app/mpyl/src/mpyl/__main__.py"]
+ENTRYPOINT ["python", "/app/mpyl/src/mpyl/__main__.py"]
 CMD ["health"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,11 +19,10 @@ RUN pip install pipenv
 # Switch to mpyl source code directory
 WORKDIR /app/mpyl
 
-# Github overrides the $HOME directory to /github/home and this causes all kinds of issues, so we're forced to create a
-# new user that has access to that directory
-# see https://github.com/actions/runner/issues/863
-RUN useradd -U github -o --uid 1000 -d /github/home
-USER github
+# Github overrides the $HOME directory to /github/home and this causes all kinds of permissions issues, so we're forced
+# to run this image as root until they decide to fix this glaring issue.
+# See https://github.com/actions/runner/issues/863 for more details.
+# USER vdbnonroot
 
 # Install the project dependencies.
 ENV LANG=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ WORKDIR /app/mpyl
 # to run this image as root until they decide to fix this glaring issue.
 # See https://github.com/actions/runner/issues/863 for more details.
 # USER vdbnonroot
+ENV WORKON_HOME=/github/home
+ENV PIPENV_CUSTOM_VENV_NAME=gh-mpyl
 
 # Install the project dependencies.
 ENV LANG=C.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,13 @@ RUN pip install pipenv
 # Switch to mpyl source code directory
 WORKDIR /app/mpyl
 
+# Github overrides the $HOME directory to /github/home and this causes all kinds of issues, so we're forced to create a
+# new user that has access to that directory
+# see https://github.com/actions/runner/issues/863
+RUN useradd -U github -o --uid 1000 -d /github/home
+USER github
+
 # Install the project dependencies.
-USER vdbnonroot
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
 COPY Pipfile Pipfile.lock ./
@@ -39,7 +44,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # the application crashes without emitting any logs due to buffering.
 ENV PYTHONUNBUFFERED=1
 
-## Switch to the directory of the caller repo (must be mounted while running)
+# Switch to the directory of the caller repo (must be mounted while running)
 WORKDIR /repo
 
 # Run the application.

--- a/README-dev.md
+++ b/README-dev.md
@@ -25,7 +25,7 @@ You might have to install the [IntelliJ Python plugin](https://plugins.jetbrains
 1. open the _Project Structure_ menu
 2. in _Platform Settings_ → _SDKs_ add a new SDK using _Add Python SDK from disk…_
 3. select _Virtualenv Environment_
-4. Choose _Existing environment_ and use `/home/vdbnonroot/.local/share/virtualenvs/gh-mpyl/bin/python3.13` as the path to the interpreter
+4. Choose _Existing environment_ and use `/root/.local/share/virtualenvs/gh-mpyl/bin/python3.13` as the path to the interpreter
 
 Yes, Python is a PITA 😩. We're hoping to further pre-configure this as soon as IntelliJ supports it.
 


### PR DESCRIPTION
Turns out Github decided it's a good idea to [override the `$HOME` environment variable to `/github/home`](https://github.com/actions/runner/issues/863), which causes all kinds of permission-related issues and weird bugs. For this reason, we're forced to run this container as root.
