### PR TITLE
ci: add sha to docker tag to prevent caching issues in automated test workflows

### DIFF
--- a/.github/workflows/validate-pr-actions.yaml
+++ b/.github/workflows/validate-pr-actions.yaml
@@ -39,7 +39,7 @@ jobs:
     needs: changed-files
     if: needs.changed-files.outputs.build-docker-image == 'true'
     outputs:
-      image: ${{ steps.docker-image.outputs.image }}
+      image: ${{ steps.docker-image.outputs.image-with-sha }}
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -69,13 +69,16 @@ jobs:
         uses: docker/setup-buildx-action@v3.7.1
 
       - name: Compute Docker image
-        run: echo "image=$REGISTRY/$REPOSITORY/$PROJECT:$VERSION" | tee -a "$GITHUB_OUTPUT"
+        run: |-
+          echo "image=$REGISTRY/$REPOSITORY/$PROJECT:$VERSION" | tee -a "$GITHUB_OUTPUT"
+          echo "image-with-sha=$REGISTRY/$REPOSITORY/$PROJECT:$VERSION.$SHA" | tee -a "$GITHUB_OUTPUT"
         id: docker-image
         env:
           REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
           REPOSITORY: ${{ vars.AWS_ECR_PUBLIC_ALIAS }}
           PROJECT: gh-mpyl
           VERSION: pr-${{ github.event.pull_request.number }}
+          SHA: ${{ github.sha }}
 
       - name: Build and push
         id: docker-build-push
@@ -83,7 +86,9 @@ jobs:
         with:
           file: Dockerfile
           context: .
-          tags: ${{ steps.docker-image.outputs.image }}
+          tags: |-
+            ${{ steps.docker-image.outputs.image }}
+            ${{ steps.docker-image.outputs.image-with-sha }}
           platforms: |-
             linux/amd64
             linux/arm64

--- a/src/mpyl/cli/plan.py
+++ b/src/mpyl/cli/plan.py
@@ -1,5 +1,7 @@
 """Commands related to plan"""
 
+# ptab bogus change to test pipelines
+
 import logging
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/mpyl/cli/plan.py
+++ b/src/mpyl/cli/plan.py
@@ -1,7 +1,5 @@
 """Commands related to plan"""
 
-# ptab bogus change to test pipelines
-
 import logging
 from dataclasses import dataclass
 from pathlib import Path


### PR DESCRIPTION
Publish the image using two tags:
* `gh-mpyl:pr-1234`
* `gh-mpyl:pr-1234.a3f413bc`

The first one can still be used to manually change the `action.yaml` files (to avoid having to change it on every single commit), the second one is used to automatically validate the PR. 

Green build: https://github.com/Vandebron/gh-mpyl/actions/runs/12169627176