### PR TITLE
fix: cancel releases in progress

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -14,6 +14,12 @@ on:
       - Pipfile
       - Pipfile.lock
 
+# if multiple pull requests are merged while this workflow is still running, cancel this one and build the last one
+# to include all changes
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   release:
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
This is an alternative approach to https://github.com/Vandebron/gh-mpyl/pull/119 so we can figure out which one we prefer.

### PROs
* closer to what's expected of a release pipeline
* much easier to explain, no need for a mega comment
* tiny change

### CONs
* PRs can be merged at any given time, so it's really hard to predict what happens for every specific case, e.g. what happens when a different PR is merged:
  * immediately after creating a Docker image (before updating the actions)?
  * immediately after updating the actions (before creating the tag?)
  * immediately after tagging the commit (before creating the release?)


Addresses [GUILD-1213](https://vandebron.atlassian.net/browse/GUILD-1213).


[GUILD-1213]: https://vandebron.atlassian.net/browse/GUILD-1213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ