### PR TITLE
fix: set .Release.Namespace necessary for dagster-user-deployments Helm chart

### DIFF
--- a/actions/discover-run-plan/action.yaml
+++ b/actions/discover-run-plan/action.yaml
@@ -13,7 +13,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: docker://public.ecr.aws/vdb-public/gh-mpyl:v1.0.4
+  image: docker://public.ecr.aws/vdb-public/gh-mpyl:pr-181
   args:
     - plan
     - discover

--- a/actions/generate-kubernetes-manifests/action.yaml
+++ b/actions/generate-kubernetes-manifests/action.yaml
@@ -29,7 +29,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: docker://public.ecr.aws/vdb-public/gh-mpyl:v1.0.4
+  image: docker://public.ecr.aws/vdb-public/gh-mpyl:pr-181
   args:
     - build
     - --environment

--- a/actions/health-check/action.yaml
+++ b/actions/health-check/action.yaml
@@ -7,7 +7,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: docker://public.ecr.aws/vdb-public/gh-mpyl:v1.0.4
+  image: docker://public.ecr.aws/vdb-public/gh-mpyl:pr-181
   args:
     - health
   env:

--- a/actions/lint-projects/action.yaml
+++ b/actions/lint-projects/action.yaml
@@ -7,7 +7,7 @@ inputs:
     required: false
 runs:
   using: docker
-  image: docker://public.ecr.aws/vdb-public/gh-mpyl:v1.0.4
+  image: docker://public.ecr.aws/vdb-public/gh-mpyl:pr-181
   args:
     - projects
     - lint

--- a/src/mpyl/steps/deploy/dagster.py
+++ b/src/mpyl/steps/deploy/dagster.py
@@ -69,6 +69,7 @@ class DagsterBase:
     def generate_kubernetes_manifests(
         logger: Logger,
         release_name: str,
+        namespace: Optional[str],
         chart_version: str,
         values_path: Path,
     ) -> Output:
@@ -76,6 +77,7 @@ class DagsterBase:
         template_chart_command = template_chart(
             logger=logger,
             release_name=release_name,
+            namespace=namespace,
             chart_name="dagster/dagster-user-deployments",
             chart_version=chart_version,
             values_path=values_path / Path("values.yaml"),
@@ -239,9 +241,14 @@ class HelmTemplateDagster(Step, DagsterBase):
 
         kubernetes_manifests_generation_result = self.generate_kubernetes_manifests(
             self._logger,
-            release_name,
-            dagster_config.user_code_helm_chart_version,
-            values_path,
+            release_name=release_name,
+            namespace=(
+                deployment.namespace
+                if (deployment := step_input.project_execution.project.deployment)
+                else None
+            ),
+            chart_version=dagster_config.user_code_helm_chart_version,
+            values_path=values_path,
         )
 
         self._logger.info("Kubernetes manifests written")
@@ -299,9 +306,14 @@ class TemplateDagster(Step, DagsterBase):
 
         kubernetes_manifests_generation_result = self.generate_kubernetes_manifests(
             self._logger,
-            release_name,
-            dagster_config.user_code_helm_chart_version,
-            values_path,
+            release_name=release_name,
+            namespace=(
+                deployment.namespace
+                if (deployment := step_input.project_execution.project.deployment)
+                else None
+            ),
+            chart_version=dagster_config.user_code_helm_chart_version,
+            values_path=values_path,
         )
 
         self._logger.info("Kubernetes manifests written")

--- a/src/mpyl/steps/deploy/k8s/helm.py
+++ b/src/mpyl/steps/deploy/k8s/helm.py
@@ -36,7 +36,7 @@ def template_chart(
         cmd = (
             f"helm template {release_name} "
             f"{chart_name} "
-            f"--namespace {namespace}"
+            f"--namespace {namespace} "
             f"--version {chart_version} "
             f"-f {values_path} "
             f"--output-dir {output_path}"

--- a/src/mpyl/steps/deploy/k8s/helm.py
+++ b/src/mpyl/steps/deploy/k8s/helm.py
@@ -5,6 +5,7 @@ step.
 import shutil
 from logging import Logger
 from pathlib import Path
+from typing import Optional
 
 import yaml
 
@@ -25,14 +26,16 @@ def update_repo(logger: Logger) -> Output:
 def template_chart(
     logger: Logger,
     release_name: str,
+    namespace: Optional[str],
     chart_name: str,
     chart_version: str,
     values_path: Path,
     output_path: Path,
 ) -> Output:
     cmd = (
-        f"helm template {release_name} "
-        f"{chart_name} "
+        f"helm template {release_name} " f"{chart_name} " f"--namespace {namespace}"
+        if namespace
+        else ""
         f"--version {chart_version} "
         f"-f {values_path} "
         f"--output-dir {output_path}"

--- a/src/mpyl/steps/deploy/k8s/helm.py
+++ b/src/mpyl/steps/deploy/k8s/helm.py
@@ -32,14 +32,23 @@ def template_chart(
     values_path: Path,
     output_path: Path,
 ) -> Output:
-    cmd = (
-        f"helm template {release_name} " f"{chart_name} " f"--namespace {namespace}"
-        if namespace
-        else ""
-        f"--version {chart_version} "
-        f"-f {values_path} "
-        f"--output-dir {output_path}"
-    )
+    if namespace:
+        cmd = (
+            f"helm template {release_name} "
+            f"{chart_name} "
+            f"--namespace {namespace}"
+            f"--version {chart_version} "
+            f"-f {values_path} "
+            f"--output-dir {output_path}"
+        )
+    else:
+        cmd = (
+            f"helm template {release_name} "
+            f"{chart_name} "
+            f"--version {chart_version} "
+            f"-f {values_path} "
+            f"--output-dir {output_path}"
+        )
     return custom_check_output(logger, cmd)
 
 

--- a/src/mpyl/steps/deploy/k8s/helm.py
+++ b/src/mpyl/steps/deploy/k8s/helm.py
@@ -32,23 +32,17 @@ def template_chart(
     values_path: Path,
     output_path: Path,
 ) -> Output:
+    cmd = (
+        f"helm template {release_name} "
+        f"{chart_name} "
+        f"--version {chart_version} "
+        f"-f {values_path} "
+        f"--output-dir {output_path}"
+    )
+
     if namespace:
-        cmd = (
-            f"helm template {release_name} "
-            f"{chart_name} "
-            f"--namespace {namespace} "
-            f"--version {chart_version} "
-            f"-f {values_path} "
-            f"--output-dir {output_path}"
-        )
-    else:
-        cmd = (
-            f"helm template {release_name} "
-            f"{chart_name} "
-            f"--version {chart_version} "
-            f"-f {values_path} "
-            f"--output-dir {output_path}"
-        )
+        cmd += f" --namespace {namespace}"
+
     return custom_check_output(logger, cmd)
 
 


### PR DESCRIPTION
Fixes [GUILD-1268](https://vandebron.atlassian.net/browse/GUILD-1268).

The dagster-user-deployments Helm chart [sets the values for the `configmap-env-shared.yaml` file](https://github.com/dagster-io/dagster/blob/06897b89f37363854b1ee5f8e3e8775615994dc6/helm/dagster/charts/dagster-user-deployments/templates/configmap-env-shared.yaml#L12) directly [from `.Release.Namespace` without falling back to anything user-defined](https://github.com/dagster-io/dagster/blob/06897b89f37363854b1ee5f8e3e8775615994dc6/helm/dagster/charts/dagster-user-deployments/templates/helpers/_helpers.tpl#L90), meaning we need to set this flag during the `helm template` invocation otherwise these values will fallback to the `default` namespace and cause the Dagster job not to start (because it cannot access the other resources correctly deployed to the `dagster` namespace). 

---

Validated in:
* https://github.com/Vandebron/github-actions/pull/354
* https://github.com/Vandebron/scripting/pull/4685
* deployment to test:
  * https://github.com/Vandebron/scripting/actions/runs/13183053590
  * https://github.com/Vandebron/argocd/pull/22749/files
* deployment to acceptance:
  * https://github.com/Vandebron/scripting/actions/runs/13183164687
  * https://github.com/Vandebron/argocd/pull/22750/files


[GUILD-1268]: https://vandebron.atlassian.net/browse/GUILD-1268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ