### PR TITLE
revert: "fix: create a common chart per deployment if needed (#191)"

### DIFF
--- a/mpyl_config.example.yml
+++ b/mpyl_config.example.yml
@@ -57,6 +57,8 @@ project:  # default values
   allowedMaintainers: [Team1, Team2, MPyL]
   deployment:
     kubernetes:
+      imagePullSecrets:
+        - name: acme-registry
       job:
         ttlSecondsAfterFinished:
           all: 3600

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -316,6 +316,7 @@ class Kubernetes:
     metrics: Optional[Metrics]
     resources: Resources
     job: Optional[Job]
+    image_pull_secrets: dict
     role: Optional[dict]
     command: Optional[TargetProperty[str]]
     args: Optional[TargetProperty[str]]
@@ -331,6 +332,7 @@ class Kubernetes:
             metrics=Metrics.from_config(values.get("metrics", {})),
             resources=Resources.from_config(values.get("resources", {})),
             job=Job.from_config(values.get("job", {})),
+            image_pull_secrets=values.get("imagePullSecrets", {}),
             role=values.get("role"),
             command=TargetProperty.from_config(values.get("command", {})),
             args=TargetProperty.from_config(values.get("args", {})),
@@ -546,8 +548,8 @@ class Project:
         return "project-override-*.yml"
 
     @staticmethod
-    def traefik_yaml_file_name(deployment_name: str) -> str:
-        return f"{deployment_name}-traefik.yml"
+    def traefik_yaml_file_name(service_name: str) -> str:
+        return f"{service_name}-traefik.yml"
 
     @property
     def root_path(self) -> Path:

--- a/src/mpyl/schema/project.schema.yml
+++ b/src/mpyl/schema/project.schema.yml
@@ -759,6 +759,12 @@ definitions:
         additionalProperties: false
       portMappings:
         type: object
+      imagePullSecrets:
+        minItems: 1
+        description: 'ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod'
+        items:
+          $ref: k8s_api_core.schema.yml#/definitions/io.k8s.api.core.v1.LocalObjectReference
+        type: [array, null]
       job:
         type: object
         additionalProperties: true

--- a/src/mpyl/steps/deploy/k8s/__init__.py
+++ b/src/mpyl/steps/deploy/k8s/__init__.py
@@ -62,32 +62,18 @@ def substitute_namespaces(
             return f"pr-{pr_identifier}"
         return project.namespace(target)
 
-    def replace_namespace(
-        original_value: str,
-        service_name: str,
-        namespace: str,
-    ):
-        search_value = service_name + ".{namespace}"
-        replace_value = service_name + "." + namespace
-        replaced_namespace = original_value.replace(search_value, replace_value)
-        updated_pr = replace_pr_number(replaced_namespace, pr_identifier)
-        if updated_pr != original_value:
-            env[key] = updated_pr
+    def replace_namespace(env_value: str, project_name: str, namespace: str) -> str:
+        search_value = project_name + ".{namespace}"
+        replace_value = project_name + "." + namespace
+        return env_value.replace(search_value, replace_value)
 
     for project in all_projects:
         linked_project_namespace = get_namespace_for_linked_project(project)
         for key, value in env.items():
-            replace_namespace(
-                original_value=value,
-                service_name=project.name,
-                namespace=linked_project_namespace,
+            replaced_namespace = replace_namespace(
+                value, project.name, linked_project_namespace
             )
-
-            for deployment in project.deployments:
-                replace_namespace(
-                    original_value=value,
-                    service_name=deployment.name,
-                    namespace=linked_project_namespace,
-                )
+            updated_pr = replace_pr_number(replaced_namespace, pr_identifier)
+            env[key] = updated_pr
 
     return env

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -40,14 +40,12 @@ def to_user_code_values(
         )
     sealed_secret_refs = []
     for sealed_secret_env in builder.get_sealed_secret_as_env_vars(
-        combined_sealed_secrets, builder.release_name
+        combined_sealed_secrets
     ):
         sealed_secret_env.value_from.secret_key_ref.name = release_name
         sealed_secret_refs.append(to_dict(sealed_secret_env, skip_none=True))
 
-    sealed_secret_manifest = builder.to_sealed_secrets(
-        combined_sealed_secrets, release_name
-    )
+    sealed_secret_manifest = builder.to_sealed_secrets(combined_sealed_secrets)
     sealed_secret_manifest.metadata.name = release_name
 
     extra_manifests = (

--- a/tests/steps/deploy/k8s/chart/templates/cronjob/cronjob-cronjob.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/cronjob/cronjob-cronjob.yaml
@@ -10,7 +10,7 @@ metadata:
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: cronjob-cronjob
+  name: cronjob
 spec:
   concurrencyPolicy: Allow
   failedJobsHistoryLimit: 1
@@ -30,7 +30,7 @@ spec:
             maintainer: MPyL
             version: pr-1234
             revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-          name: cronjob-cronjob
+          name: cronjob
         spec:
           containers:
           - args:
@@ -44,11 +44,11 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: SOME_SECRET_ENV
-                  name: cronjob-cronjob
+                  name: cronjob
                   optional: false
             image: registry/image:123
             imagePullPolicy: Always
-            name: cronjob-cronjob
+            name: cronjob
             resources:
               limits:
                 cpu: 500m

--- a/tests/steps/deploy/k8s/chart/templates/cronjob/prometheus-rule.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/cronjob/prometheus-rule.yaml
@@ -6,15 +6,14 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: cronjob
     app.kubernetes.io/instance: cronjob
-    vandebron.nl/deployment: cronjob
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: cronjob-cronjob
+  name: cronjob-prometheus-rule
 spec:
   groups:
-  - name: cronjob-cronjob-group
+  - name: cronjob-prometheus-rule-group
     rules:
     - alert: JobError
       annotations:

--- a/tests/steps/deploy/k8s/chart/templates/cronjob/sealed-secrets.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/cronjob/sealed-secrets.yaml
@@ -5,7 +5,7 @@ metadata:
     sealedsecrets.bitnami.com/cluster-wide: 'true'
   labels:
     chart: service-0.1.0
-  name: cronjob-cronjob
+  name: cronjob
 spec:
   encryptedData:
     SOME_SECRET_ENV: 

--- a/tests/steps/deploy/k8s/chart/templates/cronjob/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/cronjob/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: aws-ecr
+- name: acme-registry
 kind: ServiceAccount
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/deployment/deployment-testDeploymentStrategyParameters.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/deployment/deployment-testDeploymentStrategyParameters.yaml
@@ -13,7 +13,7 @@ metadata:
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: testdeploymentstrategyparameters-testdeploymentstrategyparameters
+  name: testdeploymentstrategyparameters
 spec:
   replicas: 1
   selector:
@@ -32,7 +32,6 @@ spec:
         app.kubernetes.io/version: pr-1234
         app.kubernetes.io/name: testdeploymentstrategyparameters
         app.kubernetes.io/instance: testdeploymentstrategyparameters
-        vandebron.nl/deployment: testdeploymentstrategyparameters
         maintainers: MPyL
         maintainer: MPyL
         version: pr-1234
@@ -56,7 +55,7 @@ spec:
           periodSeconds: 30
           successThreshold: 0
           timeoutSeconds: 20
-        name: testdeploymentstrategyparameters-testdeploymentstrategyparameters
+        name: service
         ports:
         - containerPort: 8080
           name: port-0

--- a/tests/steps/deploy/k8s/chart/templates/deployment/deployment-testDeploymentsStrategyParameters1.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/deployment/deployment-testDeploymentsStrategyParameters1.yaml
@@ -13,7 +13,7 @@ metadata:
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: testdeploymentsstrategyparameters-testdeploymentsstrategyparameters1
+  name: testdeploymentsstrategyparameters
 spec:
   replicas: 1
   selector:
@@ -32,7 +32,6 @@ spec:
         app.kubernetes.io/version: pr-1234
         app.kubernetes.io/name: testdeploymentsstrategyparameters
         app.kubernetes.io/instance: testdeploymentsstrategyparameters
-        vandebron.nl/deployment: testdeploymentsstrategyparameters1
         maintainers: MPyL
         maintainer: MPyL
         version: pr-1234
@@ -45,7 +44,7 @@ spec:
           value: PullRequest
         image: registry/image:123
         imagePullPolicy: Always
-        name: testdeploymentsstrategyparameters-testdeploymentsstrategyparameters1
+        name: service
         ports:
         - containerPort: 8080
           name: port-0

--- a/tests/steps/deploy/k8s/chart/templates/deployment/deployment-testDeploymentsStrategyParameters2.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/deployment/deployment-testDeploymentsStrategyParameters2.yaml
@@ -13,7 +13,7 @@ metadata:
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: testdeploymentsstrategyparameters-testdeploymentsstrategyparameters2
+  name: testdeploymentsstrategyparameters
 spec:
   replicas: 1
   selector:
@@ -32,7 +32,6 @@ spec:
         app.kubernetes.io/version: pr-1234
         app.kubernetes.io/name: testdeploymentsstrategyparameters
         app.kubernetes.io/instance: testdeploymentsstrategyparameters
-        vandebron.nl/deployment: testdeploymentsstrategyparameters2
         maintainers: MPyL
         maintainer: MPyL
         version: pr-1234
@@ -45,7 +44,7 @@ spec:
           value: PullRequest
         image: registry/image:123
         imagePullPolicy: Always
-        name: testdeploymentsstrategyparameters-testdeploymentsstrategyparameters2
+        name: service
         ports:
         - containerPort: 8080
           name: port-0

--- a/tests/steps/deploy/k8s/chart/templates/deployments/cronjob-cronJobDeployment.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/deployments/cronjob-cronJobDeployment.yaml
@@ -10,7 +10,7 @@ metadata:
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: deploymentsproject-cronjobdeployment
+  name: deploymentsproject
 spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
@@ -29,13 +29,13 @@ spec:
             maintainer: MPyL
             version: pr-1234
             revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-          name: deploymentsproject-cronjobdeployment
+          name: deploymentsproject
         spec:
           containers:
           - env: []
             image: registry/image:123
             imagePullPolicy: Always
-            name: deploymentsproject-cronjobdeployment
+            name: deploymentsproject
             resources:
               limits:
                 cpu: 500m

--- a/tests/steps/deploy/k8s/chart/templates/deployments/job-jobDeployment.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/deployments/job-jobDeployment.yaml
@@ -28,13 +28,13 @@ spec:
         maintainer: MPyL
         version: pr-1234
         revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-      name: deploymentsproject-jobdeployment
+      name: deploymentsproject
     spec:
       containers:
       - env: []
         image: registry/image:123
         imagePullPolicy: Always
-        name: deploymentsproject-jobdeployment
+        name: deploymentsproject
         resources:
           limits:
             cpu: 500m

--- a/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress-prod/minimalService-ingress-0-https.yaml
@@ -6,22 +6,21 @@ metadata:
     app.kubernetes.io/version: 20230829-1234
     app.kubernetes.io/name: minimalservice
     app.kubernetes.io/instance: minimalservice
-    vandebron.nl/deployment: minimalservice
     maintainers: MPyL
     maintainer: MPyL
     version: 20230829-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: minimalservice-minimalservice-https-0
+  name: minimalservice-ingress-0-https
 spec:
   routes:
   - kind: Rule
     match: Host(`mpyl-minimalservice.prod-backend.nl`)
     services:
-    - name: minimalservice-minimalservice
+    - name: minimalservice
       kind: Service
       port: 8080
     middlewares:
-    - name: whitelist-0-minimalservice-minimalservice
+    - name: minimalservice-ingress-0-whitelist
   entryPoints:
   - websecure
   tls:

--- a/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/ingress/minimalService-ingress-0-https.yaml
@@ -6,22 +6,21 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: minimalservice
     app.kubernetes.io/instance: minimalservice
-    vandebron.nl/deployment: minimalservice
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: minimalservice-minimalservice-https-0
+  name: minimalservice-ingress-0-https
 spec:
   routes:
   - kind: Rule
     match: Host(`minimalservice-1234.test-backend.nl`)
     services:
-    - name: minimalservice-minimalservice
+    - name: minimalservice
       kind: Service
       port: 8080
     middlewares:
-    - name: whitelist-0-minimalservice-minimalservice
+    - name: minimalservice-ingress-0-whitelist
   entryPoints:
   - websecure
   tls:

--- a/tests/steps/deploy/k8s/chart/templates/job/job-job.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/job/job-job.yaml
@@ -28,7 +28,7 @@ spec:
         maintainer: MPyL
         version: pr-1234
         revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-      name: job-job
+      name: job
     spec:
       containers:
       - args:
@@ -42,11 +42,11 @@ spec:
           valueFrom:
             secretKeyRef:
               key: SOME_SECRET_ENV
-              name: job-job
+              name: job
               optional: false
         image: registry/image:123
         imagePullPolicy: Always
-        name: job-job
+        name: job
         resources:
           limits:
             cpu: 500m

--- a/tests/steps/deploy/k8s/chart/templates/job/prometheus-rule.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/job/prometheus-rule.yaml
@@ -2,27 +2,26 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    name: dockertest
+    name: job
     app.kubernetes.io/version: pr-1234
-    app.kubernetes.io/name: dockertest
-    app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
+    app.kubernetes.io/name: job
+    app.kubernetes.io/instance: job
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest
+  name: job-prometheus-rule
 spec:
   groups:
-  - name: dockertest-dockertest-group
+  - name: job-prometheus-rule-group
     rules:
-    - alert: ServiceError
+    - alert: JobError
       annotations:
-        description: Service has encountered errors
+        description: Job has encountered errors
       expr: 'true'
       for: 1m
       labels:
-        alertname: ServiceError
+        alertname: JobError
         severity: warning
     - alert: the name of the alert
       annotations:

--- a/tests/steps/deploy/k8s/chart/templates/job/sealed-secrets.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/job/sealed-secrets.yaml
@@ -5,8 +5,8 @@ metadata:
     sealedsecrets.bitnami.com/cluster-wide: 'true'
   labels:
     chart: service-0.1.0
-  name: dockertest-dockertest
+  name: job
 spec:
   encryptedData:
-    SOME_SEALED_SECRET_ENV: 
+    SOME_SECRET_ENV: 
       AgCA5/qvMMp/qOyXA62f/4k89gB9vk/G9pwLzMwUH9ytqP97ml9V7+shq01Khkgz638uJz8UTff92cU2iq3yLAiElAEdQb0lwBCvG7qMXSeTkmCpZVJc8+oLbAC2m6IX3qXYFiOzwCrvrFiyPf1vxZGMcedJf0+13938yFyrPnnCH+DZGLReFWtJfp5POcvktaz9tv4kAz4LCvvwvFgPVeO3fxM2PDnegvbX7K2ojwftaFoyu0rOBylQaUsMGZd9KcFxuPnY6RXSrGh5lbyFHRZRy3RtrsWGy7Vh/vwMRjeHM3ORN4WeLQXpCRpvegD7bngXmR9yFuuD9FLDw/Wapllhv1sRX4uP2C9Fghdp005g/8iQ8IUHbC/7Rp967xs9YU6UO3kIURCQabvXpmDQ7kNbAcnDjilBY4WR8Wcsu3KJRA6dcpiZhhuQ7JbKNtySGhnRtzDuamuFUXTx8qkiegB0I8Db7Fd9K2I4bOuqhHoEgp9miQEWkd60rO5vcOqeuGzZE12ZN8XB8Iq4/QRWWafl8pjKrDf+r9ASFHUt2eAnvzK6GkGrZzZ2NRCew2csPU5V0iodkHZL+OpKQQ181J7YuJ4spziyOkzIBRRGwkrxfLmVAt5r6B5gcSsU30iOkHmbSgE37uDJAiSJmsnkzrkWARTKzEYGgvJcxKxI0ftsx5SggHCItSdnKlNBQ23bSTTdCKM1kJe0eHWHKg==

--- a/tests/steps/deploy/k8s/chart/templates/job/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/job/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: aws-ecr
+- name: acme-registry
 kind: ServiceAccount
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/deployment-dockertest.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/deployment-dockertest.yaml
@@ -13,7 +13,7 @@ metadata:
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest
+  name: dockertest
 spec:
   replicas: 3
   selector:
@@ -32,7 +32,6 @@ spec:
         app.kubernetes.io/version: pr-1234
         app.kubernetes.io/name: dockertest
         app.kubernetes.io/instance: dockertest
-        vandebron.nl/deployment: dockertest
         maintainers: MPyL
         maintainer: MPyL
         version: pr-1234
@@ -52,7 +51,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: SOME_SEALED_SECRET_ENV
-              name: dockertest-dockertest
+              name: dockertest
               optional: false
         - name: SOME_SECRET_ENV
           valueFrom:
@@ -83,7 +82,7 @@ spec:
           periodSeconds: 30
           successThreshold: 0
           timeoutSeconds: 20
-        name: dockertest-dockertest
+        name: service
         ports:
         - containerPort: 80
           name: port-0

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-http.yaml
@@ -6,23 +6,22 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest-http-0
+  name: dockertest-ingress-0-http
 spec:
   routes:
   - kind: Rule
     match: Host(`payments-1234.test.nl`)
     services:
-    - name: dockertest-dockertest
+    - name: dockertest
       kind: Service
       port: 8080
     middlewares:
     - name: traefik-https-redirect@kubernetescrd
-    - name: whitelist-0-dockertest-dockertest
+    - name: dockertest-ingress-0-whitelist
     syntax: v2
   entryPoints:
   - web

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-https.yaml
@@ -6,25 +6,26 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest-https-1
+  name: dockertest-ingress-0-https
 spec:
   routes:
   - kind: Rule
-    match: Host(`some.other.host.com`)
+    match: Host(`payments-1234.test.nl`)
     services:
-    - name: dockertest-dockertest
+    - name: dockertest
       kind: Service
-      port: 4091
+      port: 8080
     middlewares:
-    - name: whitelist-1-dockertest-dockertest
-    syntax: v3
-    priority: 1000
+    - name: dockertest-ingress-0-whitelist
+    syntax: v2
   entryPoints:
   - websecure
   tls:
-    secretName: le-other-prod-wildcard-cert
+    secretName: le-custom-prod-wildcard-cert
+    options:
+      name: insecure-ciphers
+      namespace: traefik

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-0-whitelist.yaml
@@ -1,6 +1,8 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
+  annotations:
+    VPN: 10.0.0.1
   labels:
     name: dockertest
     app.kubernetes.io/version: pr-1234
@@ -10,8 +12,8 @@ metadata:
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: strip-prefix-dockertest
+  name: dockertest-ingress-0-whitelist
 spec:
-  stripPrefix:
-    prefixes:
-    - /service2/test/pr-1234/1234
+  ipAllowList:
+    sourceRange:
+    - 10.0.0.1

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-http.yaml
@@ -6,23 +6,22 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest-http-1
+  name: dockertest-ingress-1-http
 spec:
   routes:
   - kind: Rule
     match: Host(`some.other.host.com`)
     services:
-    - name: dockertest-dockertest
+    - name: dockertest
       kind: Service
       port: 4091
     middlewares:
     - name: traefik-https-redirect@kubernetescrd
-    - name: whitelist-1-dockertest-dockertest
+    - name: dockertest-ingress-1-whitelist
     syntax: v3
     priority: 1000
   entryPoints:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-https.yaml
@@ -6,27 +6,24 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest-https-0
+  name: dockertest-ingress-1-https
 spec:
   routes:
   - kind: Rule
-    match: Host(`payments-1234.test.nl`)
+    match: Host(`some.other.host.com`)
     services:
-    - name: dockertest-dockertest
+    - name: dockertest
       kind: Service
-      port: 8080
+      port: 4091
     middlewares:
-    - name: whitelist-0-dockertest-dockertest
-    syntax: v2
+    - name: dockertest-ingress-1-whitelist
+    syntax: v3
+    priority: 1000
   entryPoints:
   - websecure
   tls:
-    secretName: le-custom-prod-wildcard-cert
-    options:
-      name: insecure-ciphers
-      namespace: traefik
+    secretName: le-other-prod-wildcard-cert

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-1-whitelist.yaml
@@ -10,12 +10,11 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: whitelist-1-dockertest-dockertest
+  name: dockertest-ingress-1-whitelist
 spec:
   ipAllowList:
     sourceRange:

--- a/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-intracloud-https-0.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/dockertest-ingress-intracloud-https-0.yaml
@@ -6,7 +6,6 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
@@ -17,7 +16,7 @@ spec:
   - kind: Rule
     match: Host(`payments-1234.test.nl`)
     services:
-    - name: dockertest-dockertest
+    - name: dockertest
       kind: Service
       port: 8080
     middlewares:

--- a/tests/steps/deploy/k8s/chart/templates/service/ingress-routes-dockertest.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/ingress-routes-dockertest.yaml
@@ -6,12 +6,11 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest
+  name: ingress-routes-dockertest
 spec:
   entryPoints:
   - web
@@ -19,4 +18,4 @@ spec:
   - kind: Rule
     match: placeholder-test-pr-1234-1234-test
     middlewares:
-    - name: strip-prefix
+    - name: strip-prefix-dockertest

--- a/tests/steps/deploy/k8s/chart/templates/service/middleware-strip-prefix.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/middleware-strip-prefix.yaml
@@ -1,20 +1,17 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  annotations:
-    VPN: 10.0.0.1
   labels:
     name: dockertest
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: whitelist-0-dockertest-dockertest
+  name: strip-prefix
 spec:
-  ipAllowList:
-    sourceRange:
-    - 10.0.0.1
+  stripPrefix:
+    prefixes:
+    - /service

--- a/tests/steps/deploy/k8s/chart/templates/service/prometheus-rule.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/prometheus-rule.yaml
@@ -2,27 +2,26 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   labels:
-    name: job
+    name: dockertest
     app.kubernetes.io/version: pr-1234
-    app.kubernetes.io/name: job
-    app.kubernetes.io/instance: job
-    vandebron.nl/deployment: job
+    app.kubernetes.io/name: dockertest
+    app.kubernetes.io/instance: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: job-job
+  name: dockertest-prometheus-rule
 spec:
   groups:
-  - name: job-job-group
+  - name: dockertest-prometheus-rule-group
     rules:
-    - alert: JobError
+    - alert: ServiceError
       annotations:
-        description: Job has encountered errors
+        description: Service has encountered errors
       expr: 'true'
       for: 1m
       labels:
-        alertname: JobError
+        alertname: ServiceError
         severity: warning
     - alert: the name of the alert
       annotations:

--- a/tests/steps/deploy/k8s/chart/templates/service/sealed-secrets.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/sealed-secrets.yaml
@@ -5,8 +5,8 @@ metadata:
     sealedsecrets.bitnami.com/cluster-wide: 'true'
   labels:
     chart: service-0.1.0
-  name: job-job
+  name: dockertest
 spec:
   encryptedData:
-    SOME_SECRET_ENV: 
+    SOME_SEALED_SECRET_ENV: 
       AgCA5/qvMMp/qOyXA62f/4k89gB9vk/G9pwLzMwUH9ytqP97ml9V7+shq01Khkgz638uJz8UTff92cU2iq3yLAiElAEdQb0lwBCvG7qMXSeTkmCpZVJc8+oLbAC2m6IX3qXYFiOzwCrvrFiyPf1vxZGMcedJf0+13938yFyrPnnCH+DZGLReFWtJfp5POcvktaz9tv4kAz4LCvvwvFgPVeO3fxM2PDnegvbX7K2ojwftaFoyu0rOBylQaUsMGZd9KcFxuPnY6RXSrGh5lbyFHRZRy3RtrsWGy7Vh/vwMRjeHM3ORN4WeLQXpCRpvegD7bngXmR9yFuuD9FLDw/Wapllhv1sRX4uP2C9Fghdp005g/8iQ8IUHbC/7Rp967xs9YU6UO3kIURCQabvXpmDQ7kNbAcnDjilBY4WR8Wcsu3KJRA6dcpiZhhuQ7JbKNtySGhnRtzDuamuFUXTx8qkiegB0I8Db7Fd9K2I4bOuqhHoEgp9miQEWkd60rO5vcOqeuGzZE12ZN8XB8Iq4/QRWWafl8pjKrDf+r9ASFHUt2eAnvzK6GkGrZzZ2NRCew2csPU5V0iodkHZL+OpKQQ181J7YuJ4spziyOkzIBRRGwkrxfLmVAt5r6B5gcSsU30iOkHmbSgE37uDJAiSJmsnkzrkWARTKzEYGgvJcxKxI0ftsx5SggHCItSdnKlNBQ23bSTTdCKM1kJe0eHWHKg==

--- a/tests/steps/deploy/k8s/chart/templates/service/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: aws-ecr
+- name: acme-registry
 kind: ServiceAccount
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/service-monitor.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service-monitor.yaml
@@ -6,12 +6,11 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest
+  name: dockertest-service-monitor
 spec:
   endpoints:
   - honorLabels: true

--- a/tests/steps/deploy/k8s/chart/templates/service/service.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service.yaml
@@ -9,12 +9,11 @@ metadata:
     app.kubernetes.io/version: pr-1234
     app.kubernetes.io/name: dockertest
     app.kubernetes.io/instance: dockertest
-    vandebron.nl/deployment: dockertest
     maintainers: MPyL
     maintainer: MPyL
     version: pr-1234
     revision: 2ad3293a7675d08bc037ef0846ef55897f38ec8f
-  name: dockertest-dockertest
+  name: dockertest
 spec:
   ports:
   - name: 8080-webservice-port
@@ -24,5 +23,4 @@ spec:
   selector:
     app.kubernetes.io/instance: dockertest
     app.kubernetes.io/name: dockertest
-    vandebron.nl/deployment: dockertest
   type: ClusterIP

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -440,7 +440,7 @@ spec:
 # service-account
 apiVersion: v1
 imagePullSecrets:
-- name: aws-ecr
+- name: acme-registry
 kind: ServiceAccount
 metadata:
   labels:

--- a/tests/test_resources/mpyl_config.yml
+++ b/tests/test_resources/mpyl_config.yml
@@ -85,7 +85,7 @@ project: # default values
       tls: "le-custom-prod-wildcard-cert"
     kubernetes:
       imagePullSecrets:
-        - name: 'aws-ecr'
+        - name: 'acme-registry'
       job:
         ttlSecondsAfterFinished:
           all: 3600

--- a/tests/test_resources/test_projects/traefik/dockertest-traefik.yml
+++ b/tests/test_resources/test_projects/traefik/dockertest-traefik.yml
@@ -7,7 +7,7 @@ traefik:
         - kind: Rule
           match: placeholder-test-{namespace}-{PR-NUMBER}-test
           middlewares:
-            - name: "strip-prefix"
+            - name: "strip-prefix-{SERVICE-NAME}"
   middlewares:
     all:
       - metadata:
@@ -17,7 +17,7 @@ traefik:
             prefixes:
               - "/service"
       - metadata:
-          name: "strip-prefix"
+          name: "strip-prefix-{SERVICE-NAME}"
         spec:
           stripPrefix:
             prefixes:


### PR DESCRIPTION
This reverts commit ff390b23998211a0bc72bbb3ad72161d3a45a45e, reversing changes made to a7af95f8e2f9c396f3819a49402a124135f24f54.

This reverts https://github.com/Vandebron/gh-mpyl/pull/191 since it was incomplete and causing production issues, and we need to merge and release https://github.com/Vandebron/gh-mpyl/pull/207 and https://github.com/Vandebron/gh-mpyl/pull/209 meanwhile. These changes can be re-applied once we start working on the remaining tickets in https://vandebron.atlassian.net/browse/GUILD-1317. 