### PR TITLE
cleanup: removed imagePullSecrets from project.yml

### DIFF
--- a/mpyl_config.example.yml
+++ b/mpyl_config.example.yml
@@ -57,8 +57,6 @@ project:  # default values
   allowedMaintainers: [Team1, Team2, MPyL]
   deployment:
     kubernetes:
-      imagePullSecrets:
-        - name: acme-registry
       job:
         ttlSecondsAfterFinished:
           all: 3600

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -316,7 +316,6 @@ class Kubernetes:
     metrics: Optional[Metrics]
     resources: Resources
     job: Optional[Job]
-    image_pull_secrets: dict
     role: Optional[dict]
     command: Optional[TargetProperty[str]]
     args: Optional[TargetProperty[str]]
@@ -332,7 +331,6 @@ class Kubernetes:
             metrics=Metrics.from_config(values.get("metrics", {})),
             resources=Resources.from_config(values.get("resources", {})),
             job=Job.from_config(values.get("job", {})),
-            image_pull_secrets=values.get("imagePullSecrets", {}),
             role=values.get("role"),
             command=TargetProperty.from_config(values.get("command", {})),
             args=TargetProperty.from_config(values.get("args", {})),

--- a/src/mpyl/schema/project.schema.yml
+++ b/src/mpyl/schema/project.schema.yml
@@ -759,12 +759,6 @@ definitions:
         additionalProperties: false
       portMappings:
         type: object
-      imagePullSecrets:
-        minItems: 1
-        description: 'ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod'
-        items:
-          $ref: k8s_api_core.schema.yml#/definitions/io.k8s.api.core.v1.LocalObjectReference
-        type: [array, null]
       job:
         type: object
         additionalProperties: true

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -60,9 +60,6 @@ def to_user_code_values(
             "serviceAccount": {"create": service_account_override is None},
             # ucd, short for user-code-deployment
             "fullnameOverride": f"ucd-{shorten_name(project.name)}{name_suffix}",
-            "imagePullSecrets": [
-                {"name": "aws-ecr"},
-            ],
             "deployments": [
                 {
                     "dagsterApiGrpcArgs": [

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_with_extra_manifest.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_with_extra_manifest.yaml
@@ -1,8 +1,6 @@
 serviceAccount:
   create: true
 fullnameOverride: ucd-educ-pr-1234
-imagePullSecrets:
-- name: aws-ecr
 deployments:
 - dagsterApiGrpcArgs:
   - --python-file

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_with_global_service_account.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_with_global_service_account.yaml
@@ -3,8 +3,6 @@ global:
 serviceAccount:
   create: false
 fullnameOverride: ucd-educ-pr-1234
-imagePullSecrets:
-- name: aws-ecr
 deployments:
 - dagsterApiGrpcArgs:
   - --python-file

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_with_target_prod.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_with_target_prod.yaml
@@ -3,8 +3,6 @@ global:
 serviceAccount:
   create: false
 fullnameOverride: ucd-educ
-imagePullSecrets:
-- name: aws-ecr
 deployments:
 - dagsterApiGrpcArgs:
   - --python-file

--- a/tests/steps/deploy/dagster/dagster-user-deployments/values_without_global_service_account.yaml
+++ b/tests/steps/deploy/dagster/dagster-user-deployments/values_without_global_service_account.yaml
@@ -1,8 +1,6 @@
 serviceAccount:
   create: true
 fullnameOverride: ucd-educ-pr-1234
-imagePullSecrets:
-- name: aws-ecr
 deployments:
 - dagsterApiGrpcArgs:
   - --python-file

--- a/tests/steps/deploy/k8s/chart/templates/cronjob/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/cronjob/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: acme-registry
+- name: aws-ecr
 kind: ServiceAccount
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/job/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/job/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: acme-registry
+- name: aws-ecr
 kind: ServiceAccount
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/chart/templates/service/service-account.yaml
+++ b/tests/steps/deploy/k8s/chart/templates/service/service-account.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 imagePullSecrets:
-- name: acme-registry
+- name: aws-ecr
 kind: ServiceAccount
 metadata:
   labels:

--- a/tests/steps/deploy/k8s/templates/manifest.yaml
+++ b/tests/steps/deploy/k8s/templates/manifest.yaml
@@ -406,7 +406,7 @@ metadata:
   name: dockertest
 spec:
   encryptedData:
-    SOME_SEALED_SECRET_ENV: 
+    SOME_SEALED_SECRET_ENV:
       AgCA5/qvMMp/qOyXA62f/4k89gB9vk/G9pwLzMwUH9ytqP97ml9V7+shq01Khkgz638uJz8UTff92cU2iq3yLAiElAEdQb0lwBCvG7qMXSeTkmCpZVJc8+oLbAC2m6IX3qXYFiOzwCrvrFiyPf1vxZGMcedJf0+13938yFyrPnnCH+DZGLReFWtJfp5POcvktaz9tv4kAz4LCvvwvFgPVeO3fxM2PDnegvbX7K2ojwftaFoyu0rOBylQaUsMGZd9KcFxuPnY6RXSrGh5lbyFHRZRy3RtrsWGy7Vh/vwMRjeHM3ORN4WeLQXpCRpvegD7bngXmR9yFuuD9FLDw/Wapllhv1sRX4uP2C9Fghdp005g/8iQ8IUHbC/7Rp967xs9YU6UO3kIURCQabvXpmDQ7kNbAcnDjilBY4WR8Wcsu3KJRA6dcpiZhhuQ7JbKNtySGhnRtzDuamuFUXTx8qkiegB0I8Db7Fd9K2I4bOuqhHoEgp9miQEWkd60rO5vcOqeuGzZE12ZN8XB8Iq4/QRWWafl8pjKrDf+r9ASFHUt2eAnvzK6GkGrZzZ2NRCew2csPU5V0iodkHZL+OpKQQ181J7YuJ4spziyOkzIBRRGwkrxfLmVAt5r6B5gcSsU30iOkHmbSgE37uDJAiSJmsnkzrkWARTKzEYGgvJcxKxI0ftsx5SggHCItSdnKlNBQ23bSTTdCKM1kJe0eHWHKg==
 ---
 # service
@@ -440,7 +440,7 @@ spec:
 # service-account
 apiVersion: v1
 imagePullSecrets:
-- name: acme-registry
+- name: aws-ecr
 kind: ServiceAccount
 metadata:
   labels:


### PR DESCRIPTION
This configuration value is [only used in 6 places in our entire organization](https://github.com/search?q=org%3AVandebron+imagePullSecrets+path%3Aproject.yml+-repo%3AVandebron%2Ftest-tag-pipelines-here&type=code) and always with the same value (`aws-ecr`), so we're hardcoding this in MPyL to simplify things.

When applying this change I'll also remove the settings from those `project.yml` files.

--- 

Split from https://github.com/Vandebron/gh-mpyl/pull/191