### PR TITLE
Feature/data 2739 adding readiness probe options to dagster

### DIFF
--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -416,7 +416,7 @@ class Dagster:
         return Dagster(
             repo=values.get("repo", ""),
             secrets=[DagsterSecret.from_config(v) for v in values.get("secrets", [])],
-            readiness_probe_script=values.get("readinessProbeScript", ""),
+            readiness_probe_script=values.get("readinessProbeScript"),
         )
 
 

--- a/src/mpyl/project.py
+++ b/src/mpyl/project.py
@@ -409,12 +409,14 @@ class DagsterSecret:
 class Dagster:
     repo: str
     secrets: List[DagsterSecret]
+    readiness_probe_script: Optional[str]
 
     @staticmethod
     def from_config(values: dict):
         return Dagster(
             repo=values.get("repo", ""),
             secrets=[DagsterSecret.from_config(v) for v in values.get("secrets", [])],
+            readiness_probe_script=values.get("readinessProbeScript", ""),
         )
 
 

--- a/src/mpyl/schema/project.schema.yml
+++ b/src/mpyl/schema/project.schema.yml
@@ -110,6 +110,11 @@ properties:
         type: string
         examples:
           - /python/my_project/dagster/repo.py
+      readinessProbeScript:
+        description: Path to a script that will be used to check if the Dagster server is ready.
+        type: string
+        examples:
+          - /python/my_project/dagster/readiness_probe.py
   build:
     type: object
     additionalProperties: false

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -27,7 +27,7 @@ def to_user_code_values(  # pylint: disable=too-many-locals
     project = builder.project
 
     global_override = {}
-    if not service_account_override is None: 
+    if not service_account_override is None:
         global_override = {"global": {"serviceAccountName": service_account_override}}
 
     combined_sealed_secrets: list[KeyValueProperty] = []

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -27,7 +27,7 @@ def to_user_code_values(  # pylint: disable=too-many-locals
     project = builder.project
 
     global_override = {}
-    if not service_account_override is None:
+    if not service_account_override is None: 
         global_override = {"global": {"serviceAccountName": service_account_override}}
 
     combined_sealed_secrets: list[KeyValueProperty] = []
@@ -61,6 +61,24 @@ def to_user_code_values(  # pylint: disable=too-many-locals
         if len(sealed_secret_refs) > 0
         else {}
     )
+
+    if (
+        project.dagster.readiness_probe_script
+        and project.dagster.readiness_probe_script.strip()
+    ):
+        readiness_probe = {
+            "readinessProbe": {
+                "exec": {
+                    "command": ["python", project.dagster.readiness_probe_script],
+                },
+                "periodSeconds": 20,
+                "timeoutSeconds": 30,
+                "successThreshold": 1,
+                "failureThreshold": 3,
+            }
+        }
+    else:
+        readiness_probe = {}
 
     return (
         global_override
@@ -104,6 +122,7 @@ def to_user_code_values(  # pylint: disable=too-many-locals
                         },
                         "vandebron.nl/dagster": "user-code-deployment",
                     },
+                    **readiness_probe,
                     "includeConfigInLaunchedRuns": {"enabled": True},
                     "name": release_name,
                     "port": 3030,

--- a/src/mpyl/steps/deploy/k8s/resources/dagster.py
+++ b/src/mpyl/steps/deploy/k8s/resources/dagster.py
@@ -62,11 +62,8 @@ def to_user_code_values(  # pylint: disable=too-many-locals
         else {}
     )
 
-    if (
-        project.dagster.readiness_probe_script
-        and project.dagster.readiness_probe_script.strip()
-    ):
-        readiness_probe = {
+    readiness_probe = (
+        {
             "readinessProbe": {
                 "exec": {
                     "command": ["python", project.dagster.readiness_probe_script],
@@ -77,8 +74,9 @@ def to_user_code_values(  # pylint: disable=too-many-locals
                 "failureThreshold": 3,
             }
         }
-    else:
-        readiness_probe = {}
+        if project.dagster.readiness_probe_script
+        else {}
+    )
 
     return (
         global_override


### PR DESCRIPTION
In this PR we are trying to add an option to have readiness probes options to dagster deployments. Basically, we want to just add a path to a script that needs to run for that readiness probe, and have this inserted into the helm chart of the Dagster's User Code Deployment